### PR TITLE
AMD GPU support

### DIFF
--- a/Source/ASManager.cpp
+++ b/Source/ASManager.cpp
@@ -31,6 +31,7 @@ using namespace RTGL1;
 
 ASManager::ASManager(
     VkDevice _device,
+    std::shared_ptr<PhysicalDevice> physDevice,
     std::shared_ptr<MemoryAllocator> _allocator,
     std::shared_ptr<CommandBufferManager> _cmdManager,
     std::shared_ptr<TextureManager> _textureManager,
@@ -76,8 +77,8 @@ ASManager::ASManager(
         tlas[i] = std::make_unique<TLASComponent>(device, "TLAS main");
     }
 
-
-    scratchBuffer = std::make_shared<ScratchBuffer>(allocator);
+    const uint32_t scratchOffsetAligment = physDevice->GetASProperties().minAccelerationStructureScratchOffsetAlignment;
+    scratchBuffer = std::make_shared<ScratchBuffer>(allocator, scratchOffsetAligment);
     asBuilder = std::make_shared<ASBuilder>(device, scratchBuffer);
 
 

--- a/Source/ASManager.h
+++ b/Source/ASManager.h
@@ -50,6 +50,7 @@ public:
 
 public:
     ASManager(VkDevice device, 
+              std::shared_ptr<PhysicalDevice> physDevice,
               std::shared_ptr<MemoryAllocator> allocator,
               std::shared_ptr<CommandBufferManager> cmdManager,
               std::shared_ptr<TextureManager> textureManager,

--- a/Source/PathTracer.cpp
+++ b/Source/PathTracer.cpp
@@ -71,9 +71,30 @@ void PathTracer::Bind(
                             0, nullptr);
 }
 
-void PathTracer::TracePrimaryRays(VkCommandBuffer cmd, uint32_t frameIndex, uint32_t width, uint32_t height)
+void PathTracer::TracePrimaryRays(VkCommandBuffer cmd, uint32_t frameIndex,
+                                  uint32_t width, uint32_t height,
+                                  const std::shared_ptr<Framebuffers>& framebuffers)
 {
     CmdLabel label(cmd, "Primary rays");
+
+    typedef FramebufferImageIndex FI;
+    FI fs[] =
+    {
+        FI::FB_IMAGE_INDEX_RANDOM_SEED,
+        FI::FB_IMAGE_INDEX_ALBEDO,
+        FI::FB_IMAGE_INDEX_NORMAL,
+        FI::FB_IMAGE_INDEX_NORMAL_GEOMETRY,
+        FI::FB_IMAGE_INDEX_METALLIC_ROUGHNESS,
+        FI::FB_IMAGE_INDEX_DEPTH,
+        FI::FB_IMAGE_INDEX_MOTION,
+        FI::FB_IMAGE_INDEX_SURFACE_POSITION,
+        FI::FB_IMAGE_INDEX_VISIBILITY_BUFFER,
+        FI::FB_IMAGE_INDEX_VIEW_DIRECTION,
+        FI::FB_IMAGE_INDEX_SECTOR_INDEX,
+        FI::FB_IMAGE_INDEX_THROUGHPUT,
+        FI::FB_IMAGE_INDEX_PRIMARY_TO_REFL_REFR,
+    };
+    framebuffers->BarrierMultiple(cmd, frameIndex, fs);
 
     VkStridedDeviceAddressRegionKHR raygenEntry, missEntry, hitEntry, callableEntry;
 

--- a/Source/PathTracer.h
+++ b/Source/PathTracer.h
@@ -52,7 +52,8 @@ public:
     
     void TracePrimaryRays(
         VkCommandBuffer cmd, uint32_t frameIndex,
-        uint32_t width, uint32_t height);
+        uint32_t width, uint32_t height,
+        const std::shared_ptr<Framebuffers>& framebuffers);
 
     void TraceReflectionRefractionRays(
         VkCommandBuffer cmd, uint32_t frameIndex,

--- a/Source/PhysicalDevice.cpp
+++ b/Source/PhysicalDevice.cpp
@@ -28,7 +28,7 @@
 using namespace RTGL1;
 
 PhysicalDevice::PhysicalDevice(VkInstance instance)
-    : physDevice(VK_NULL_HANDLE), memoryProperties{}, rtPipelineProperties{}
+    : physDevice(VK_NULL_HANDLE), memoryProperties{}, rtPipelineProperties{}, asProperties{}
 {
     VkResult r;
 
@@ -60,9 +60,11 @@ PhysicalDevice::PhysicalDevice(VkInstance instance)
             physDevice = p;
 
             rtPipelineProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
+            asProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR;
             VkPhysicalDeviceProperties2 deviceProp2 = {};
             deviceProp2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
             deviceProp2.pNext = &rtPipelineProperties;
+            rtPipelineProperties.pNext = &asProperties;
 
             vkGetPhysicalDeviceProperties2(physDevice, &deviceProp2);
             vkGetPhysicalDeviceMemoryProperties(physDevice, &memoryProperties);
@@ -130,4 +132,9 @@ const VkPhysicalDeviceMemoryProperties &PhysicalDevice::GetMemoryProperties() co
 const VkPhysicalDeviceRayTracingPipelinePropertiesKHR &PhysicalDevice::GetRTPipelineProperties() const
 {
     return rtPipelineProperties;
+}
+
+const VkPhysicalDeviceAccelerationStructurePropertiesKHR& PhysicalDevice::GetASProperties() const
+{
+    return asProperties;
 }

--- a/Source/PhysicalDevice.h
+++ b/Source/PhysicalDevice.h
@@ -40,12 +40,14 @@ public:
     uint32_t GetMemoryTypeIndex(uint32_t memoryTypeBits, VkFlags requirementsMask) const;
     const VkPhysicalDeviceMemoryProperties &GetMemoryProperties() const;
     const VkPhysicalDeviceRayTracingPipelinePropertiesKHR &GetRTPipelineProperties() const;
+    const VkPhysicalDeviceAccelerationStructurePropertiesKHR& GetASProperties() const;
 
 private:
     // selected physical device
     VkPhysicalDevice physDevice;
     VkPhysicalDeviceMemoryProperties memoryProperties;
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR rtPipelineProperties;
+    VkPhysicalDeviceAccelerationStructurePropertiesKHR asProperties;
 };
 
 }

--- a/Source/Scene.cpp
+++ b/Source/Scene.cpp
@@ -27,6 +27,7 @@ using namespace RTGL1;
 
 Scene::Scene(
     VkDevice _device,
+    std::shared_ptr<PhysicalDevice> _physDevice,
     std::shared_ptr<MemoryAllocator> &_allocator,
     std::shared_ptr<CommandBufferManager> &_cmdManager,
     std::shared_ptr<TextureManager> &_textureManager,
@@ -46,7 +47,7 @@ Scene::Scene(
     geomInfoMgr = std::make_shared<GeomInfoManager>(_device, _allocator);
     triangleInfoMgr = std::make_shared<TriangleInfoManager>(_device, _allocator, sectorVisibility);
 
-    asManager = std::make_shared<ASManager>(_device, _allocator, _cmdManager, _textureManager, geomInfoMgr, triangleInfoMgr, sectorVisibility, _properties);
+    asManager = std::make_shared<ASManager>(_device, _physDevice, _allocator, _cmdManager, _textureManager, geomInfoMgr, triangleInfoMgr, sectorVisibility, _properties);
   
     vertPreproc = std::make_shared<VertexPreprocessing>(_device, _uniform, asManager, _shaderManager);
 }

--- a/Source/Scene.h
+++ b/Source/Scene.h
@@ -33,6 +33,7 @@ class Scene
 public:
     explicit Scene(
         VkDevice device,
+        std::shared_ptr<PhysicalDevice> physDevice,
         std::shared_ptr<MemoryAllocator> &allocator,
         std::shared_ptr<CommandBufferManager> &cmdManager,
         std::shared_ptr<TextureManager> &textureManager,

--- a/Source/ScratchBuffer.h
+++ b/Source/ScratchBuffer.h
@@ -30,7 +30,7 @@ namespace RTGL1
 class ScratchBuffer
 {
 public:
-    explicit ScratchBuffer(std::shared_ptr<MemoryAllocator> allocator);
+    explicit ScratchBuffer(std::shared_ptr<MemoryAllocator> allocator, uint32_t alignment = 1);
 
     ScratchBuffer(const ScratchBuffer& other) = delete;
     ScratchBuffer(ScratchBuffer&& other) noexcept = delete;
@@ -53,6 +53,7 @@ private:
 
     std::weak_ptr<MemoryAllocator> allocator;
     std::list<ChunkBuffer> chunks;
+    uint32_t alignment = 1;
 };
 
 }

--- a/Source/VulkanDevice.cpp
+++ b/Source/VulkanDevice.cpp
@@ -133,6 +133,7 @@ VulkanDevice::VulkanDevice(const RgInstanceCreateInfo *info) :
 
     scene               = std::make_shared<Scene>(
         device,
+        physDevice,
         memAllocator,
         cmdManager,
         textureManager,

--- a/Source/VulkanDevice.cpp
+++ b/Source/VulkanDevice.cpp
@@ -818,7 +818,7 @@ void VulkanDevice::Render(VkCommandBuffer cmd, const RgDrawFrameInfo &drawInfo)
             scene, uniform, textureManager, 
             framebuffers, blueNoise, cubemapManager, rasterizer->GetRenderCubemap());
 
-        pathTracer->TracePrimaryRays(cmd, frameIndex, renderResolution.Width(), renderResolution.Height());
+        pathTracer->TracePrimaryRays(cmd, frameIndex, renderResolution.Width(), renderResolution.Height(), framebuffers);
 
         // draw decals on top of primary surface
         decalManager->Draw(cmd, frameIndex, uniform, framebuffers, textureManager);


### PR DESCRIPTION
This PR contains the following fixes for AMD RDNA2:
- Ensure device addresses are aligned as per hardware constraints. Usually AMD resources have 1 byte alignment, but this is not the case for some RT addresses which must be aligned to the driver constraint (256)
- Insert a missing set of image memory barriers between frame N-2 and the current frame N. It seems AMD keeps a lot of work in-flight and you end up with data hazards without proper barriers, which smears Nans all over the screen.

Results:
![image](https://user-images.githubusercontent.com/15904127/162583822-f5024bda-78da-4b75-8fdf-29888d196b37.png)

Known issues:
- Random crashing, though I'm unsure if it has anything to do with the executable or not. There is a spec violation about maxRecursion value (2) in shaders being higher than the AMD setting which is 1, but fixing this has no impact on stability.
- The player's hand gets smeary after transitioning between levels. This seems to be the cause of the crashing. The glitch resembles messed up motion vectors when implementing TAA, but I haven't checked any further. Booting directly into any level seems to work fine.

Tested with DOOM1 full game iwad.
 