### PR TITLE
Add missing transfer->read barrier for autobuffers

### DIFF
--- a/Source/AutoBuffer.cpp
+++ b/Source/AutoBuffer.cpp
@@ -111,6 +111,17 @@ void RTGL1::AutoBuffer::CopyFromStaging(VkCommandBuffer cmd, uint32_t frameIndex
         cmd,
         staging[frameIndex].GetBuffer(), deviceLocal.GetBuffer(),
         1, &info);
+
+    VkBufferMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.buffer = deviceLocal.GetBuffer();
+    barrier.offset = offset;
+    barrier.size = size;
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
 }
 
 void RTGL1::AutoBuffer::CopyFromStaging(
@@ -129,6 +140,21 @@ void RTGL1::AutoBuffer::CopyFromStaging(
         cmd,
         staging[frameIndex].GetBuffer(), deviceLocal.GetBuffer(),
         copyInfosCount, copyInfos);
+
+    VkBufferMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.buffer = deviceLocal.GetBuffer();
+
+    for (uint32_t i = 0; i < copyInfosCount; ++i)
+    {
+        barrier.offset = copyInfos[i].dstOffset;
+        barrier.size = copyInfos[i].size;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+    }
 }
 
 void *RTGL1::AutoBuffer::GetMapped(uint32_t frameIndex)


### PR DESCRIPTION
This caused a data hazard with bizzare side-effects. Basically the results of the traceRay operation yielded different results that calculating the hit manually using barycentric coordinates because the vertex lookup relies on uniform buffers which were not yet initialized with the current frame data. This would lead to the access returning values from the previous frame(s) - sometimes several frames old - which in turn corrupted the motion vectors and created the hallucinated artifacts in the denoiser. 
This fix completely solves https://github.com/sultim-t/prboom-plus-rt/issues/38 for me. The crashing is also gone, I played most of episode one in a single sitting with no crashes observed. Hopefully it is fixed for others as well.