### PR TITLE
[AMD Fix] Insert a COMPUTE->FRAGMENT stage transition barrier before drawing the HUD

### DIFF
--- a/Source/VulkanDevice.cpp
+++ b/Source/VulkanDevice.cpp
@@ -723,6 +723,8 @@ void RTGL1::VulkanDevice::Render( VkCommandBuffer cmd, const RgDrawFrameInfo& dr
     // draw geometry such as HUD into an upscaled framebuf
     if( !drawInfo.disableRasterization )
     {
+        framebuffers->BarrierOne( cmd, frameIndex, accum, RTGL1::Framebuffers::BarrierType::Storage );
+
         rasterizer->DrawToSwapchain( cmd,
                                      frameIndex,
                                      accum,


### PR DESCRIPTION
Addresses https://github.com/sultim-t/xash-rt/issues/3
Avoids a race between the two stages and fixes the garbled HUD on AMD GPUs.

![image](https://user-images.githubusercontent.com/15904127/221899136-c7678799-2222-4747-907c-5ea99cdebfd4.png)
